### PR TITLE
Encode newline as \n, fixes GH#2

### DIFF
--- a/lib/Data/Dumper/OneLine.pm
+++ b/lib/Data/Dumper/OneLine.pm
@@ -17,6 +17,7 @@ sub Dumper {
     local $Data::Dumper::Sortkeys  = 1;
     local $Data::Dumper::Quotekeys = 0;
     local $Data::Dumper::Deparse   = 1;
+    local $Data::Dumper::Useqq     = 1;
 
     if ($Encoding) {
         $stuff = Data::Recursive::Encode->encode_utf8($stuff);
@@ -61,4 +62,3 @@ it under the same terms as Perl itself.
 Hiroki Honda E<lt>cside.story@gmail.comE<gt>
 
 =cut
-


### PR DESCRIPTION
I wonder why #2 is closed when the bug is clearly still there. Anyway, here's one way to fix the problem, by setting Useqq to 1 so newlines are encoded.
